### PR TITLE
Deprecate discourse-crowd plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# ⚠️ This plugin is no longer supported
+
 ### discourse-crowd
 
 A Discourse Plugin to enable authentication via Atlassian Crowd.

--- a/plugin.rb
+++ b/plugin.rb
@@ -7,6 +7,10 @@
 
 gem "omniauth_crowd", "2.2.3"
 
+AdminDashboardData.add_problem_check do
+  "The discourse-crowd plugin is no longer supported. Check https://meta.discourse.org/tag/auth-plugins for alternatives."
+end
+
 # mode of crowd authentication, how the discourse will behave after the user types in the
 # credentials
 class CrowdAuthenticatorMode


### PR DESCRIPTION
The upstream omniauth_crowd gem is incompatible with Omniauth v2, and most users of this plugin have already switched to more modern/standard authentication schemes